### PR TITLE
Added rules for Vanila JS

### DIFF
--- a/test/vanilla/accessor-pairs.js
+++ b/test/vanilla/accessor-pairs.js
@@ -1,0 +1,21 @@
+const objectSample = {
+  set key(value) {
+    this.valueThisObject = value;
+  },
+  get key() {
+    return this.valueThisObject;
+  },
+};
+
+const objectSampleOther = {key: 1};
+
+Object.defineProperty(objectSampleOther, 'anythingString', {
+  set: function(value) {
+    this.valueThisObject = value;
+  },
+  get: function() {
+    return this.valueThisObject;
+  },
+});
+
+throw new Error(objectSample);

--- a/test/vanilla/arrow-parens.js
+++ b/test/vanilla/arrow-parens.js
@@ -1,21 +1,23 @@
-const a = '';
-
 () => {};
 
-(a) => {return a;};
+(anything) => anything;
 
-(a) => a;
-
-(a) => {
-  return `${a} \n`;
+(anything) => {
+  anything++;
+  return anything;
 };
 
-a.then((foo) => {
-  return foo;
+(anything) => `${anything} \n`;
+
+const emptyString = '';
+
+emptyString.then((anything) => {
+  anything = `${anything}!`;
+  return anything;
 });
 
-a.then((foo) => {
-  if (foo === true) {
-    return foo;
+emptyString.then((anything) => {
+  if (typeof anything === 'string') {
+    return anything;
   }
 });

--- a/test/vanilla/camelcase.js
+++ b/test/vanilla/camelcase.js
@@ -1,0 +1,46 @@
+const textColor = '#112C85';
+const _textColor = '#112C85';
+const textColor_ = '#112C85';
+const TEXT_COLOR = '#112C85';
+
+const objectSample ={
+  key: 'key',
+};
+
+const doSomething = () => {};
+
+const value = objectSample.key;
+const instance = {
+  value: objectSample.key,
+};
+
+objectSample.do_something();
+objectSample.doSomething();
+doSomething();
+new doSomething();
+
+const categoryItem = {
+  categoryId: '001',
+  isCategory: true,
+};
+const {categoryId: categoryExample} = categoryItem;
+
+function doSomethingFirst({isCamelCasedInnerScore}) {
+  return isCamelCasedInnerScore;
+}
+
+function doSomethingSecond({isCamelCased: isAlsoCamelCased}) {
+  return isAlsoCamelCased;
+}
+
+function doSomethingThird({isCamelCasedInnerScore = 'default value'}) {
+  return isCamelCasedInnerScore;
+}
+
+const {categoryId = 1} = categoryItem;
+
+const {isCategory: isCamelCased} = categoryItem;
+
+const {isCategory: isCamelCasedOther = true} = categoryItem;
+
+throw new Error(textColor, _textColor, textColor_, TEXT_COLOR, value, instance, categoryExample, doSomethingFirst, doSomethingSecond, doSomethingThird, isCamelCased, isCamelCasedOther, categoryId);

--- a/test/vanilla/comma-dangles.js
+++ b/test/vanilla/comma-dangles.js
@@ -1,29 +1,27 @@
-const arr0 = ['a', 'b', 'c'];
-const arr1 = [
+const characters = ['a', 'b', 'c'];
+const letters = [
   'a',
   'b',
   'c',
 ];
 
-const obj0 = {q: 'q', w: 'w'};
-const obj1 = {
-  q: 'q',
-  w: 'w',
+const category = {id: 0, name: 'office'};
+const product = {
+  id: 0,
+  categoryId: 0,
+  name: 'table',
 };
 
-const func0 = (a, b) => {
-  return a + b;
-};
-const func1 = (
-  a,
-  b,
-) => {
-  return a + b;
-};
+const matchesCategory = (categoryItem, productItem) => categoryItem.id === productItem.categoryId;
 
-func0(
-  obj0.a,
-  obj0.b,
+const includesPattern = (
+  productName,
+  pattern,
+) => (typeof productName === 'string' && productName.includes(pattern));
+
+matchesCategory(
+  category,
+  product,
 );
 
-throw new Error(arr0, arr1, obj0, obj1, func0, func1);
+throw new Error(characters, letters, includesPattern);

--- a/test/vanilla/curly.js
+++ b/test/vanilla/curly.js
@@ -1,0 +1,20 @@
+const isTrue = true;
+
+const doSomething = () => {};
+const doSomethingElse = () => {};
+
+let counter = 1;
+
+if (isTrue) {
+  counter++;
+}
+
+while (isTrue) {
+  doSomething(counter);
+}
+
+if (isTrue) {
+  doSomething();
+} else {
+  doSomethingElse();
+}

--- a/test/vanilla/eqeqeq.js
+++ b/test/vanilla/eqeqeq.js
@@ -1,0 +1,12 @@
+const conditionLeft = 'str';
+const conditionRight = 'str';
+
+conditionLeft === conditionRight;
+conditionLeft === true;
+conditionLeft !== 1;
+conditionLeft === undefined;
+typeof undefinedVariable === 'undefined';
+'hello' !== 'world';
+0 === 0;
+true === true;
+conditionLeft === null;

--- a/test/vanilla/indent.js
+++ b/test/vanilla/indent.js
@@ -1,48 +1,40 @@
-'use strict';
-
 // Continuation, aka MemberExpression
 const promise = window.Promise.resolve(true);
 promise.
-  then((data) => {
-    return data;
-  }).
-  then((truthy) => {
-    return !truthy;
-  }).
-  catch(() => {
-    return false;
-  });
+  then((data) => data).
+  then((truthy) => !truthy).
+  catch(() => false);
 
 // Function expression
-const fun = function (first, second) {
-  return first + second;
+const calculateSum = function (sum, price) {
+  return sum + price;
 };
 
 // Function declaration
-function Constructor(first, second) {
+function Constructor(name, price) {
   this.data = {
-    first: first,
-    second: second,
+    name: name,
+    price: price,
   };
 }
 
 // Calling site arguments
-const myObject = new Constructor(
+const objectSample = new Constructor(
   'Petya',
   'Vasya',
 );
-myObject.toString();
+objectSample.toString();
 
-const result = fun(
-  'one',
-  'two',
+const result = calculateSum(
+  10000,
+  1000,
 );
 result.toString();
 
 // Switch
-const a = 'a';
+const symbol = 'a';
 
-switch(a) {
+switch(symbol) {
   case 'a':
     break;
   case 'b':

--- a/test/vanilla/no-shadow.js
+++ b/test/vanilla/no-shadow.js
@@ -1,0 +1,16 @@
+const isTrue = true;
+
+const doEnything = () => {};
+
+if (isTrue) {
+  const coordinateX = 3;
+  const coordinateY = 6;
+
+  doEnything(coordinateX, coordinateY);
+}
+
+const coordinateZ = 5;
+
+function doSomething() {}
+
+throw new Error(coordinateZ, doSomething);

--- a/test/vanilla/no-useless-concat.js
+++ b/test/vanilla/no-useless-concat.js
@@ -1,0 +1,16 @@
+const price = 100;
+const discount = 50;
+const count = 5;
+
+const fullPrice = price - discount;
+const discountMessage = `Discount is ${price * (discount / 100)}%`;
+const fullPriceMessage = `${fullPrice}  - FULL price!`;
+const countAfterBuy = count - 1;
+const countAfterRefund = count + 1;
+
+// when the string concatenation is multiline
+const fullMessage = 'It' +
+  'will' +
+  'make you happy!';
+
+throw new Error(discountMessage, fullPriceMessage, countAfterBuy, countAfterRefund, fullMessage);

--- a/test/vanilla/no-useless-return.js
+++ b/test/vanilla/no-useless-return.js
@@ -1,0 +1,42 @@
+const isTrue = true;
+
+const doSomething = () => {};
+const doSomethingElse = () => {};
+const doDefault = () => {};
+
+function getNumberFive() { return 5; }
+
+function getFunction() {
+  return () => {};
+}
+
+function doSomethingWithIf() {
+  if (isTrue) {
+    doSomething();
+    return;
+  } else {
+    doSomethingElse();
+  }
+  doDefault();
+}
+
+function doSomethingWithSwitch() {
+  switch (isTrue) {
+    case 1:
+      doSomething();
+      return;
+    default:
+      doSomethingElse();
+  }
+}
+
+function doSomethingWithArray() {
+  const numbers = [1, 2, 3];
+  for (const number of numbers) {
+    if (number === 1) {
+      return number;
+    }
+  }
+}
+
+throw new Error(getNumberFive, getFunction, doSomethingWithIf, doSomethingWithSwitch, doSomethingWithArray);

--- a/test/vanilla/no-var.js
+++ b/test/vanilla/no-var.js
@@ -1,6 +1,6 @@
-let a = 0;
-a = 1;
+let number = 0;
+number = 1;
 
-const B = 'B';
+const letter = 'B';
 
-throw new Error (a, B);
+throw new Error (number, letter);

--- a/test/vanilla/prefer-arrow-callback.js
+++ b/test/vanilla/prefer-arrow-callback.js
@@ -1,38 +1,34 @@
-const func0 = (fun) => fun();
+const doEnything = (fun) => fun();
 
 // arrow function callback
-func0((a) => a);
-
-func0((a) => {
-  return a;
-});
+doEnything(() => {});
 
 // generator as callback
-func0(function*() { yield; });
+doEnything(function*() { yield; });
 
 // function expression not used as callback or function argument
-const func1 = function foo(a) {
-  return a;
+const doEnythingUsefull = function foo(value) {
+  return value;
 };
 
 // recursive named function callback
-func0(function bar(n) {
-  return n && n + bar(n - 1);
+doEnything(function doEnythingElse(value) {
+  return value && value + doEnythingElse(value - 1);
 });
 
 // Default: { allowNamedFunctions: false, allowUnboundThis: true }
 // 'allowUnboundThis': true, gives access to use next espressions
 
 // unbound function expression callback
-func0(function() {
-  return this.a;
+doEnything(function() {
+  return this.key;
 });
 
-func0(function() {
-  this.a;
+doEnything(function() {
+  this.key;
 });
 
-func0(function() {
+doEnything(function() {
   (() => this);
 });
 
@@ -42,4 +38,4 @@ const someObject = {};
   return this.doSomething(item);
 }, someObject);
 
-throw new Error(func0, func1);
+throw new Error(doEnythingUsefull);

--- a/test/vanilla/prefer-const.js
+++ b/test/vanilla/prefer-const.js
@@ -1,11 +1,11 @@
-for (const num in [1, 2]) {
-  throw new Error(num);
+for (const number in [1, 2]) {
+  throw new Error(number);
 }
 
-for (const num of [1, 2]) {
-  throw new Error(num);
+for (const number of [1, 2]) {
+  throw new Error(number);
 }
 
-for (let num = 0, end = 2; num < end; ++num) {
-  throw new Error(num);
+for (let number = 0, end = 2; number < end; ++number) {
+  throw new Error(number);
 }

--- a/test/vanilla/prefer-template.js
+++ b/test/vanilla/prefer-template.js
@@ -1,0 +1,7 @@
+const nameOfPerson = 'Name';
+
+const message = 'Hello World!';
+const messageWithName = `Hello, ${nameOfPerson}!`;
+const messageWithCalculate = `Time: ${12 * 60 * 60 * 1000}`;
+
+throw new Error(message, messageWithName, messageWithCalculate);

--- a/test/vanilla/quotes.js
+++ b/test/vanilla/quotes.js
@@ -1,6 +1,6 @@
-const a = 'Anything string';
-const b = `Anything
+const template = 'Anything string';
+const templateLiteralMultiline = `Anything
 string`;
-const c = `This's a ${a}`;
+const templateLiteralInline = `This's a ${template}`;
 
-throw new Error(a, b, c);
+throw new Error(template, templateLiteralMultiline, templateLiteralInline);

--- a/test/vanilla/radix.js
+++ b/test/vanilla/radix.js
@@ -1,0 +1,4 @@
+const numInDecimal = parseInt('071', 10);
+const numInOctal = parseInt('071', 8);
+
+throw new Error(numInDecimal, numInOctal);

--- a/test/vanilla/semi.js
+++ b/test/vanilla/semi.js
@@ -1,16 +1,16 @@
-const a = 'a';
+const letter = 'a';
 
-const func0 = () => { return; };
+const doSomething = () => {};
 
-const func1 = (a) => a;
+const doSomethingElse = (template) => template;
 
-const func2 = () => { func0(); };
+const checkEnything = () => { doSomething(); };
 
-const func3 = () => { func0(); func1(); };
+const checkEnythingInline = () => { doSomething(); doSomethingElse(); };
 
-const func4 = () => {
-  func0();
-  func1();
+const checkEnythingMultiline = () => {
+  doSomething();
+  doSomethingElse();
 };
 
-throw new Error (a, func0, func1, func2, func3, func4);
+throw new Error (letter, checkEnything, checkEnythingInline, checkEnythingMultiline);

--- a/vanilla.js
+++ b/vanilla.js
@@ -5,29 +5,53 @@ module.exports = {
     // https://eslint.org/docs/rules/#possible-errors
     // ---------------------------------------------
     'no-console': 'error',
+    'no-template-curly-in-string': 'error',
+    // Best Practices
+    // https://eslint.org/docs/rules/#best-practices
+    'accessor-pairs': 'error',
+    'curly': 'error',
+    'eqeqeq': ['error', 'always'],
+    'no-alert': 'error',
+    'no-useless-concat': 'error',
+    'no-useless-return': 'error',
+    'radix': 'error',
+    // Strict Mode
+    // https://eslint.org/docs/rules/#strict-mode
+    'strict': ['error', 'global'],
+    // Variables
+    // https://eslint.org/docs/rules/#variables
+    'no-shadow': ['error', {'hoist': 'all'}],
+    'no-use-before-define': 'error',
     // Stylistic Issues
     // https://eslint.org/docs/rules/#stylistic-issues
     // ---------------------------------------------
+    'camelcase': 'error',
     'comma-dangle': ['error', {
       'arrays': 'always-multiline',
       'objects': 'always-multiline',
       'functions': 'always-multiline',
     }],
+    'eol-last': 'error',
+    'id-length': 'error',
     'indent': ['error', 2, {
       SwitchCase: 1,
     }],
+    'lines-between-class-members': ['error', 'always'],
+    'no-multiple-empty-lines': 'error',
+    'no-nested-ternary': 'error',
+    'no-trailing-spaces': 'error',
+    'no-unneeded-ternary': 'error',
     'quotes': ['error', 'single'],
+    'semi': 'error',
+    'semi-style': 'error',
     // ECMAScript 6
     // https://eslint.org/docs/rules/#ecmascript-6
     // ---------------------------------------------
-    'no-var': 'error',
-    'prefer-const': 'error',
-    'prefer-arrow-callback': 'error',
-    'eol-last': 'error',
-    'no-multiple-empty-lines': 'error',
-    'semi': 'error',
-    'semi-style': 'error',
-    'no-trailing-spaces': 'error',
+    'arrow-body-style': ['error', 'as-needed'],
     'arrow-parens': 'error',
+    'no-var': 'error',
+    'prefer-arrow-callback': 'error',
+    'prefer-const': 'error',
+    'prefer-template': 'error',
   },
 };


### PR DESCRIPTION
Additional rules:
> Possible Errors
* [no-template-curly-in-string](https://eslint.org/docs/rules/no-template-curly-in-string)
> Best Practices
* [accessor-pairs](https://eslint.org/docs/rules/accessor-pairs)
* [curly](https://eslint.org/docs/rules/curly)
* [eqeqeq](https://eslint.org/docs/rules/eqeqeq)
* [no-alert](https://eslint.org/docs/rules/no-alert)
* [no-useless-concat](https://eslint.org/docs/rules/no-useless-concat)
* [no-useless-return](https://eslint.org/docs/rules/no-useless-return)
* [radix](https://eslint.org/docs/rules/radix)
> Strict Mode
* [strict](https://eslint.org/docs/rules/strict)
> Variables
* [no-shadow](https://eslint.org/docs/rules/no-shadow)
* [no-use-before-define](https://eslint.org/docs/rules/no-use-before-define)
> Stylistic Issues
* [camelcase](https://eslint.org/docs/rules/camelcase)
* [id-length](https://eslint.org/docs/rules/id-length)
* [lines-between-class-members](https://eslint.org/docs/rules/lines-between-class-members)
* [no-nested-ternary](https://eslint.org/docs/rules/no-nested-ternary)
* [no-unneeded-ternary](https://eslint.org/docs/rules/no-unneeded-ternary)
> ECMAScript 6
* [arrow-body-style](https://eslint.org/docs/rules/arrow-body-style)
* [prefer-template](https://eslint.org/docs/rules/prefer-template)