### PR TITLE
Добавил правило чтобы использовать const вместо let когда это возможно.

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -13,6 +13,7 @@ module.exports = {
       'no-new-symbol': `error`, // eslint:recommended
       'no-this-before-super': `error`, // eslint:recommended
       'no-var': `error`,
+      'prefer-const': `error`,
       'prefer-rest-params': `error`,
       'prefer-spread': `error`,
       'rest-spread-spacing': `error`,


### PR DESCRIPTION
На курсах JavaScript ур.2 и Node.js бывает что студенты используют let на тех переменых значение которые не перезаписывается и приходится искать их глазами. Думаю правильно будет чтобы eslint на это указывал. 