### PR TITLE
Разрешит не разделять пустой строкой однострочные свойства

### DIFF
--- a/vanilla.js
+++ b/vanilla.js
@@ -32,7 +32,7 @@ module.exports = {
     'indent': ['error', 2, {
       SwitchCase: 1,
     }],
-    'lines-between-class-members': ['error', 'always'],
+    'lines-between-class-members': ['error', 'always', {'exceptAfterSingleLine': true}],
     'no-multiple-empty-lines': 'error',
     'no-nested-ternary': 'error',
     'no-trailing-spaces': 'error',


### PR DESCRIPTION
Линтер считает отдельной сущностью каждое class property и требует после него пустую строку. Из-за этого  не получается "компактно" объявить поля класса:

```
class MyClass {
  a = 1;
  b = 2;
}
```

Добавление опции `{'exceptAfterSingleLine': true}` позволит не разделять пустой строкой поля-однострочники.