### PR TITLE
fix(typescript): Добавит правило регулирующее синтаксис типов

### DIFF
--- a/react-typescript.js
+++ b/react-typescript.js
@@ -11,6 +11,7 @@ module.exports = {
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': 'error',
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": ["error"]
+    "@typescript-eslint/no-unused-vars": ["error"],
+    '@typescript-eslint/member-delimiter-style': ['error']
   }
 }


### PR DESCRIPTION
Добавляет правило [`member-delimiter-style`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/member-delimiter-style.md). Данное правило обеспечивает согласованный стиль разделителей членов в интерфейсах и литералах типов. Установки правила по умолчанию:
```
{
  "multiline": {
    "delimiter": "semi",
    "requireLast": true
  },
  "singleline": {
    "delimiter": "semi",
    "requireLast": false
  },
  "multilineDetection": "brackets"
}
```